### PR TITLE
Reduce dependency on tabulate and docopt for library uses

### DIFF
--- a/GageRnR/__init__.py
+++ b/GageRnR/__init__.py
@@ -5,7 +5,6 @@ This module
 """
 from .gageRnR import GageRnR
 from .generator import Distribution, Settings, Generator
-from .__main__ import main
 from .dataLoader import DataLoader
 from .statistics import Statistics, Result, Component
 from .normality import Normality
@@ -17,7 +16,6 @@ __all__ = ['GageRnR',
            'Distribution',
            'Settings',
            'Generator',
-           'main',
            'DataLoader',
            'Statistics',
            'Normality',

--- a/GageRnR/application.py
+++ b/GageRnR/application.py
@@ -37,7 +37,6 @@ Options:
     -h --help     Show this screen.
     -v --version  Show version.
 """
-from docopt import docopt
 import os.path
 
 import GageRnR
@@ -69,6 +68,7 @@ def checkIntegerList(name, values, minValue=0):
 class Application():
 
     def __init__(self, argv=None):
+        from docopt import docopt
         arguments = docopt(__doc__, argv, version=GageRnR.__version__)
         self.file = str(arguments["--file"])
         self.structure = toInt(arguments["--structure"])

--- a/GageRnR/gageRnR.py
+++ b/GageRnR/gageRnR.py
@@ -1,8 +1,8 @@
 """Module containing the algorithm for GageRnR."""
 import numpy as np
 import math
+import pandas as pd
 import scipy.stats as stats
-from tabulate import tabulate
 from .statistics import Statistics, Result, Component, ComponentNames
 
 ResultNames = {
@@ -54,10 +54,15 @@ class GageRnR(Statistics):
 
             table.append(innerTable)
 
-        return tabulate(
-            table,
-            headers=headers,
-            tablefmt=tableFormat)
+        try:
+            from tabulate import tabulate
+            return tabulate(
+                table,
+                headers=headers,
+                tablefmt=tableFormat)            
+        except (ImportError,Exception) as _:
+            pass
+        return str(pd.DataFrame(table,columns=headers).describe())
 
     def calculate(self):
         """Calculate GageRnR."""

--- a/GageRnR/linearity.py
+++ b/GageRnR/linearity.py
@@ -1,8 +1,8 @@
 import numpy as np
-from tabulate import tabulate
 from .statistics import Statistics, Result, Component
 import statsmodels.api as sm
 import plotly.graph_objects as go
+import pandas as pd
 
 ResultNames = {
     Result.K: 'Linearity',
@@ -43,10 +43,15 @@ class Linearity(Statistics):
         results = [Result.K, Result.Bias, Result.P]
         self.addToTable(results, Component.TOTAL, table, precision)
 
-        return tabulate(
-            table,
-            headers=headers,
-            tablefmt=tableFormat)
+        try:
+            from tabulate import tabulate
+            return tabulate(
+                table,
+                headers=headers,
+                tablefmt=tableFormat)
+        except (Exception,ImportError) as _:
+            pass
+        return str(pd.DataFrame(table,columns=headers).describe())
 
     def calculatePartResiduals(self):
         means = np.repeat(

--- a/GageRnR/normality.py
+++ b/GageRnR/normality.py
@@ -1,6 +1,6 @@
 import numpy as np
 from scipy.stats import shapiro
-from tabulate import tabulate
+import pandas as pd
 from .statistics import Statistics, Result, Component
 
 ResultNames = {
@@ -38,11 +38,16 @@ class Normality(Statistics):
         self.addToTable(results, Component.OPERATOR, table, precision)
         self.addToTable(results, Component.PART, table, precision)
 
-        return tabulate(
-            table,
-            headers=headers,
+        try:
+            from tabulate import tabulate        
+            return tabulate(
+                table,
+                headers=headers,
             tablefmt=tableFormat)
-
+        except (Exception,ImportError) as _:
+            pass
+        return str(pd.DataFrame(table,columns=headers).describe())
+    
     def calculateNormality(self):
         """Shapiro-Wilk Test"""
         W = dict()

--- a/GageRnR/statistics.py
+++ b/GageRnR/statistics.py
@@ -1,6 +1,6 @@
 from enum import Enum
 import numpy as np
-from tabulate import tabulate
+import pandas as pd
 import plotly.graph_objects as go
 
 
@@ -86,11 +86,16 @@ class Statistics(object):
         self.addToTable(results, Component.OPERATOR, table, precision)
         self.addToTable(results, Component.PART, table, precision)
 
-        return tabulate(
-            table,
-            headers=headers,
-            tablefmt=tableFormat)
-
+        try:
+            import tabulate as tabulate
+            return tabulate(
+                table,
+                headers=headers,
+                tablefmt=tableFormat)
+        except (Exception,ImportError) as _:
+            pass
+        return str(pd.DataFrame(table,columns=headers).describe())
+        
     def createOperatorsBoxData(self):
         data = []
         for i in range(0, self.operators):

--- a/GageRnR/tests/test_application.py
+++ b/GageRnR/tests/test_application.py
@@ -1,5 +1,5 @@
 import unittest
-from GageRnR import main
+from GageRnR.__main__ import main
 import os
 
 

--- a/example/generator.py
+++ b/example/generator.py
@@ -25,7 +25,7 @@ settings = Settings(
     operators=operator,
     parts=parts,
     partOperator=partOperator,
-    measurments=measurements)
+    measurements=measurements)
 
 gen = Generator(settings)
 g = GageRnR(gen.data)


### PR DESCRIPTION
- make module tabulate as an optional module
- skip main function from the import bit